### PR TITLE
Fixed link to Legacy Lua API doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ET: Legacy documentation [![Documentation Status](https://readthedocs.org/projects/etlegacy/badge/?version=latest)](http://etlegacy.readthedocs.io/en/latest/?badge=latest)
 
-Reference documentation for ET: Legacy and the Legacy mod. The Lua API documentation is available [here](https://github.com/etlegacy/lua_apidoc).
+Reference documentation for ET: Legacy and the Legacy mod. The Lua API documentation is available [here](https://github.com/etlegacy/etlegacy-lua-docs).
 
 This documentation is generated with [Sphinx](http://www.sphinx-doc.org/) using the [reStructuredText](http://www.sphinx-doc.org/en/stable/rest.html) markup language.
 

--- a/index.rst
+++ b/index.rst
@@ -19,7 +19,7 @@ There are two aspects to this project:
 
 .. important:: This documentation aims to be a centralized reference only. For information about common issues, getting help or contributing to the project, ensure to visit the official `website <https://www.etlegacy.com>`_ and `wiki <https://github.com/etlegacy/etlegacy/wiki>`_.
 
-.. note:: For scripting customization of Legacy mod, check the `Lua API reference <https://legacy-lua-api.readthedocs.io/>`_.
+.. note:: For scripting customization of Legacy mod, check the `Lua API reference <https://etlegacy-lua-docs.readthedocs.io/>`_.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
It was still pointing to the deprecated old version.